### PR TITLE
Login / Registration Mobile#4

### DIFF
--- a/src/pages/AddCar.jsx
+++ b/src/pages/AddCar.jsx
@@ -43,7 +43,7 @@ const AddCar = () => {
   const sendForm = (e) => {
     e.preventDefault();
     dispatch(addCar(formData)).then((response) => {
-      if (response.status !== 'error') navigate('/cars');
+      if (response.status !== 'error') navigate('/');
     });
   };
 

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -59,7 +59,7 @@ const Login = () => {
             <p>LOG IN</p>
             <input type="text" placeholder="email" name="email" onChange={changeHandler} />
             <input type="password" placeholder="password" name="password" onChange={changeHandler} />
-            <p className={styles.error}>{session.data.error}</p>
+            <p className={styles.error}>{session.data.message}</p>
             <button type="submit" disabled={!isFormValid}>LOGIN</button>
             <Link to="/register">Create account</Link>
           </form>

--- a/src/redux/sessionSlice.js
+++ b/src/redux/sessionSlice.js
@@ -23,7 +23,6 @@ export const signUp = createAsyncThunk(
     });
 
     const data = await res.json();
-    localStorage.setItem('jti', data.user.jti);
     return data;
   },
 );
@@ -44,8 +43,9 @@ export const login = createAsyncThunk(
     });
 
     const data = await res.json();
-    localStorage.setItem('token', res.headers.get('Authorization'));
-    localStorage.setItem('jti', data.user.jti);
+    if (data.errors === false) {
+      localStorage.setItem('token', res.headers.get('Authorization'));
+    }
     return data;
   },
 );


### PR DESCRIPTION
Login / Registration Mobile#4: Adapt user structure
In this pull request, I'm adapting the new API login endpoint response, with the following changes:
- Remove the jti from the local storage (it was already stored in the user data)
- Change the error message variable
- Change the logic to store the token only if there isn't any error during the login process
- Redirect the user to the home page ("/") after create a new car  